### PR TITLE
Fixed multiple ports bug

### DIFF
--- a/sbt-plugin/src/main/resources/play/soap/sbtplugin/plugin.vm
+++ b/sbt-plugin/src/main/resources/play/soap/sbtplugin/plugin.vm
@@ -36,8 +36,12 @@ class ${service.name}(app: play.api.Application) extends play.soap.PlaySoapPlugi
 
 object ${service.name} {
 #foreach ($port in $service.ports)
-
   #set($portMethodName = $portMethod.transform($port))
+  #set($portClassName = ${port.interfaceClass})
+  #if ($portClassName == ${service.name})
+    #set($portClassName = ${port.fullClassName})
+  #end
+
   def ${portMethodName}(implicit app: play.api.Application): $portClassName = {
     app.plugin[$service.name] match {
       case Some(plugin) => plugin.$portMethodName

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/build.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/build.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "com.typesafe.play" %% "play" % play.core.PlayVersion.current

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/build.properties
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.7

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/src/main/wsdl/stockquote.wsdl
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/src/main/wsdl/stockquote.wsdl
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://www.webserviceX.NET/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://www.webserviceX.NET/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="http://www.webserviceX.NET/">
+      <s:element name="GetQuote">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="symbol" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="GetQuoteResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="GetQuoteResult" type="s:string" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+      <s:element name="string" nillable="true" type="s:string" />
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="GetQuoteSoapIn">
+    <wsdl:part name="parameters" element="tns:GetQuote" />
+  </wsdl:message>
+  <wsdl:message name="GetQuoteSoapOut">
+    <wsdl:part name="parameters" element="tns:GetQuoteResponse" />
+  </wsdl:message>
+  <wsdl:message name="GetQuoteHttpGetIn">
+    <wsdl:part name="symbol" type="s:string" />
+  </wsdl:message>
+  <wsdl:message name="GetQuoteHttpGetOut">
+    <wsdl:part name="Body" element="tns:string" />
+  </wsdl:message>
+  <wsdl:message name="GetQuoteHttpPostIn">
+    <wsdl:part name="symbol" type="s:string" />
+  </wsdl:message>
+  <wsdl:message name="GetQuoteHttpPostOut">
+    <wsdl:part name="Body" element="tns:string" />
+  </wsdl:message>
+  <wsdl:portType name="StockQuoteSoap">
+    <wsdl:operation name="GetQuote">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get Stock quote for a company Symbol</wsdl:documentation>
+      <wsdl:input message="tns:GetQuoteSoapIn" />
+      <wsdl:output message="tns:GetQuoteSoapOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:portType name="StockQuoteHttpGet">
+    <wsdl:operation name="GetQuote">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get Stock quote for a company Symbol</wsdl:documentation>
+      <wsdl:input message="tns:GetQuoteHttpGetIn" />
+      <wsdl:output message="tns:GetQuoteHttpGetOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:portType name="StockQuoteHttpPost">
+    <wsdl:operation name="GetQuote">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get Stock quote for a company Symbol</wsdl:documentation>
+      <wsdl:input message="tns:GetQuoteHttpPostIn" />
+      <wsdl:output message="tns:GetQuoteHttpPostOut" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="StockQuoteSoap" type="tns:StockQuoteSoap">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="GetQuote">
+      <soap:operation soapAction="http://www.webserviceX.NET/GetQuote" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="StockQuoteSoap12" type="tns:StockQuoteSoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="GetQuote">
+      <soap12:operation soapAction="http://www.webserviceX.NET/GetQuote" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="StockQuoteHttpGet" type="tns:StockQuoteHttpGet">
+    <http:binding verb="GET" />
+    <wsdl:operation name="GetQuote">
+      <http:operation location="/GetQuote" />
+      <wsdl:input>
+        <http:urlEncoded />
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="StockQuoteHttpPost" type="tns:StockQuoteHttpPost">
+    <http:binding verb="POST" />
+    <wsdl:operation name="GetQuote">
+      <http:operation location="/GetQuote" />
+      <wsdl:input>
+        <mime:content type="application/x-www-form-urlencoded" />
+      </wsdl:input>
+      <wsdl:output>
+        <mime:mimeXml part="Body" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="StockQuote">
+    <wsdl:port name="StockQuoteSoap" binding="tns:StockQuoteSoap">
+      <soap:address location="http://www.webservicex.net/stockquote.asmx" />
+    </wsdl:port>
+    <wsdl:port name="StockQuoteSoap12" binding="tns:StockQuoteSoap12">
+      <soap12:address location="http://www.webservicex.net/stockquote.asmx" />
+    </wsdl:port>
+    <wsdl:port name="StockQuoteHttpGet" binding="tns:StockQuoteHttpGet">
+      <http:address location="http://www.webservicex.net/stockquote.asmx" />
+    </wsdl:port>
+    <wsdl:port name="StockQuoteHttpPost" binding="tns:StockQuoteHttpPost">
+      <http:address location="http://www.webservicex.net/stockquote.asmx" />
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/test
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
If there was more than one port, each one in the plugin companion object would be declared to have the type of the last one.
