### PR TITLE
Add "guess-mime-type" to ensure HTML content type

### DIFF
--- a/docs/docs.sbt
+++ b/docs/docs.sbt
@@ -52,7 +52,7 @@ watchSources ++= (sources in generateDocs).value
 publish := {
   val stageDir = WebKeys.stage.value.getAbsolutePath
   println("Syncing files with S3")
-  val rc = s"s3cmd sync --delete-removed $stageDir/ s3://downloads.typesafe.com/rp/play-soap/".!
+  val rc = s"s3cmd sync --guess-mime-type --delete-removed $stageDir/ s3://downloads.typesafe.com/rp/play-soap/".!
   if (rc != 0) {
     throw new FeedbackProvidedException {}
   }


### PR DESCRIPTION
API is showing "application/xml" as the Content-Type header even when the suffix is .html.

Use --guess-mime-type to use MIME type for line endings:

>  Guess MIME-type of files by their extension or mime magic. Fall back to default MIME-Type as specified by --default-mime-type option
