### PR TITLE
Updates and removing uses of F.Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Play SOAP is an sbt plugin that transforms WSDLs into SOAP client interfaces, an
 To install sbt WSDL into your Play project, add the following dependency to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % "1.1.0")
 ```
 
 For more information about how to use Play SOAP, see the [documentation](#docs).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ There are a number of distinct parts to this, not all of them need to be impleme
 
 Feature           | Importance | Status      | Description
 ------------------|------------|-------------|------------
-**Client proxy**  | Required   | PoC         | Given an interface that returns responses as `scala.concurrent.Future` or `play.libs.F.Promise`, generate an asynchronous web services client that implements it.
+**Client proxy**  | Required   | PoC         | Given an interface that returns responses as `scala.concurrent.Future` or `java.util.concurrent.CompletionStage`, generate an asynchronous web services client that implements it.
 **wsdl2java**     | Required   | Not started | sbt plugin that, given a wsdl, generates the above interface
 **WS backend**    | Low        | Not started | Implement the cxf http backend using Play's WS API
 **Scala binding** | Medium     | Not started | Allow the use of Scala case classes, collections, option etc, rather than using Java beans. May use JAXB or completely different xml binding library.
@@ -31,7 +31,6 @@ In future, we may decide to implement our own reflection code for generating bin
 
 ### Next steps
 
-* Implement support for `play.libs.F.Promise`
 * Improve API for creating the client proxy (make it simpler for the simple cases)
 * Document how to create and configure the client proxy
 * Tests, and general clean up of code.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 # Reactive SOAP for Play
 
+Play SOAP allows a Play application to make calls on a remote web service using SOAP. It provides a reactive interface to doing so, making HTTP requests asynchronously and returning promises/futures of the result.
+
+## JAX WS support
+
+Play SOAP builds on the JAX WS spec, but doesn’t implement it exactly. JAX WS, while it does have support for making asynchronous calls, this support is somewhat clumsy, requiring all asynchronous methods to have an Async suffix, and requiring the passing of an AsyncHandler argument to handle the response, which makes it awkward to integrate into an asynchronous framework since AsyncHandler’s do not compose well with other asynchronous constructs. This support could be described as a second class citizen, bolted on to the spec as an after thought.
+
+In contrast, Play SOAP provides asynchronous invocation of SOAP services as a first class citizen. Play SOAP methods all return promises, making them easy to compose with promises from other libraries, and allowing application code to be focused on business logic, not on wiring asynchronous callbacks together.
+
+## Using Play SOAP
+
+Play SOAP is an sbt plugin that transforms WSDLs into SOAP client interfaces, and provides a client library that takes Play SOAP generated interfaces and dynamically implements them to make calls on remote services. The sbt plugin is called `SbtWsdl`, and this is the starting point to installing and using Play SOAP.
+
+### Using sbt WSDL
+
+#### Installation
+
+To install sbt WSDL into your Play project, add the following dependency to your `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % "1.1.0")
+```
+
+For more information about how to use Play SOAP, see the [documentation](#docs).
+
+-------------------
+
 There are a number of distinct parts to this, not all of them need to be implemented to have a viable product:
 
 Feature           | Importance | Status      | Description

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ lazy val plugin = (project in file("sbt-plugin"))
   .enablePlugins(PlaySbtPlugin)
   .settings(scriptedSettings: _*)
   .settings(
-    name := "play-soap-sbt",
-    organization := "com.typesafe.play",
+    name := "sbt-play-soap",
+    organization := "com.typesafe.sbt",
     libraryDependencies ++= Common.pluginDeps,
     addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Common.PlayVersion),
     (resourceGenerators in Compile) += generateVersionFile.taskValue,
@@ -100,7 +100,7 @@ def generateVersionFile = Def.task {
   val file = (resourceManaged in Compile).value / "play-soap.version.properties"
   val content =
     s"""play-soap-client.version=$clientVersion
-       |play-soap-sbt.version=$pluginVersion
+       |sbt-play-soap.version=$pluginVersion
      """.stripMargin
   if (!file.exists() || !(IO.read(file) == content)) {
     IO.write(file, content)

--- a/client/src/main/scala/play/soap/PlayJaxWsClientProxy.scala
+++ b/client/src/main/scala/play/soap/PlayJaxWsClientProxy.scala
@@ -28,22 +28,23 @@
  */
 package play.soap
 
-import java.io.{IOException, Closeable}
-import java.lang.reflect.{ParameterizedType, Method, InvocationTargetException}
+import java.io.{Closeable, IOException}
+import java.lang.reflect.{InvocationTargetException, Method, ParameterizedType}
 import java.net.HttpURLConnection
+import java.util.concurrent.CompletionStage
 import javax.xml.soap.{SOAPConstants, SOAPException, SOAPFault}
 import javax.xml.ws.handler.MessageContext
 import javax.xml.ws.handler.MessageContext.Scope
-import javax.xml.ws.http.{HTTPException, HTTPBinding}
-import javax.xml.ws.soap.{SOAPFaultException, SOAPBinding}
+import javax.xml.ws.http.{HTTPBinding, HTTPException}
+import javax.xml.ws.soap.{SOAPBinding, SOAPFaultException}
 import javax.xml.ws._
 
 import org.apache.cxf.binding.soap.SoapFault
-import org.apache.cxf.binding.soap.saaj.{SAAJUtils, SAAJFactoryResolver}
+import org.apache.cxf.binding.soap.saaj.{SAAJFactoryResolver, SAAJUtils}
 import org.apache.cxf.common.i18n.Message
 import org.apache.cxf.common.logging.LogUtils
 import org.apache.cxf.common.util.StringUtils
-import org.apache.cxf.endpoint.{ClientCallback, Endpoint, Client}
+import org.apache.cxf.endpoint.{Client, ClientCallback, Endpoint}
 import org.apache.cxf.frontend.ClientProxy
 import org.apache.cxf.helpers.CastUtils
 import org.apache.cxf.interceptor.Fault
@@ -51,15 +52,14 @@ import org.apache.cxf.jaxws.EndpointReferenceBuilder
 import org.apache.cxf.jaxws.context.WrappedMessageContext
 import org.apache.cxf.jaxws.support.JaxWsEndpointImpl
 import org.apache.cxf.service.invoker.MethodDispatcher
-
-import java.util.{Map => JMap, Locale}
+import java.util.{Locale, Map => JMap}
 
 import org.apache.cxf.service.model.BindingOperationInfo
 import org.w3c.dom.Node
-
 import play.libs.F
 
-import scala.concurrent.{Promise, Future}
+import scala.compat.java8.FutureConverters
+import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 private[soap] object PlayJaxWsClientProxy {
@@ -173,10 +173,10 @@ private[soap] class PlayJaxWsClientProxy(c: Client, binding: Binding) extends Cl
       val returnType: Class[_] = method.getReturnType
       if (returnType == classOf[Future[_]]) {
         invokeScalaFuture(method, oi, params)
-      } else if (returnType == classOf[F.Promise[_]]) {
+      } else if (returnType == classOf[CompletionStage[_]]) {
         invokePlayJavaFuture(method, oi, params)
       } else {
-        throw new WebServiceException(s"Can't invoke method with return type of $returnType, expected return type of scala.concurrent.Future or play.libs.F.Promise")
+        throw new WebServiceException(s"Can't invoke method with return type of $returnType, expected return type of scala.concurrent.Future or java.util.concurrent.CompletionStage")
       }
     } catch {
       case wex: WebServiceException => throw wex
@@ -247,9 +247,9 @@ private[soap] class PlayJaxWsClientProxy(c: Client, binding: Binding) extends Cl
     promise.future
   }
 
-  private def invokePlayJavaFuture(method: Method, oi: BindingOperationInfo, params: Array[AnyRef]): F.Promise[Any] = {
+  private def invokePlayJavaFuture(method: Method, oi: BindingOperationInfo, params: Array[AnyRef]): CompletionStage[Any] = {
     val future: Future[Any] = invokeScalaFuture(method, oi, params)
-    val playJavaPromise: F.Promise[Any] = F.Promise.wrap(future)
+    val playJavaPromise: CompletionStage[Any] = FutureConverters.toJava(future)
     playJavaPromise
   }
 

--- a/client/src/main/scala/play/soap/PlayServiceConfiguration.scala
+++ b/client/src/main/scala/play/soap/PlayServiceConfiguration.scala
@@ -6,7 +6,7 @@ package play.soap
 import java.lang.reflect.{Method, ParameterizedType, Type}
 
 import org.apache.cxf.wsdl.service.factory.AbstractServiceConfiguration
-import play.libs.F.Promise
+import java.util.concurrent.CompletionStage
 
 import scala.concurrent.Future
 
@@ -18,10 +18,10 @@ private[soap] class PlayServiceConfiguration extends AbstractServiceConfiguratio
    * We say future/promise is a holder type so that JAXB will create bindings for the inner type, not the outer.
    */
   override def isHolder(cls: Class[_], `type`: Type) =
-    if (classOf[Future[_]] == cls || classOf[Promise[_]] == cls) java.lang.Boolean.TRUE else null
+    if (classOf[Future[_]] == cls || classOf[CompletionStage[_]] == cls) java.lang.Boolean.TRUE else null
 
   override def getHolderType(cls: Class[_], `type`: Type) = {
-    if (classOf[Future[_]] == cls || classOf[Promise[_]] == cls) {
+    if (classOf[Future[_]] == cls || classOf[CompletionStage[_]] == cls) {
       `type` match {
         case p: ParameterizedType => p.getActualTypeArguments()(0)
       }
@@ -35,7 +35,7 @@ private[soap] class PlayServiceConfiguration extends AbstractServiceConfiguratio
     m.getGenericReturnType match {
       case future: ParameterizedType
         if future.getRawType == classOf[Future[_]] ||
-          future.getRawType == classOf[Promise[_]] =>
+          future.getRawType == classOf[CompletionStage[_]] =>
         future.getActualTypeArguments.headOption match {
           case Some(unit) if unit == classOf[Unit] || unit == classOf[Void] => FALSE
           case _ => null

--- a/client/src/test/java/play/soap/mockservice/MockServiceJava.java
+++ b/client/src/test/java/play/soap/mockservice/MockServiceJava.java
@@ -3,28 +3,27 @@
  */
 package play.soap.mockservice;
 
-import play.libs.F.Promise;
-
 import javax.jws.WebService;
 import javax.xml.ws.Action;
 import javax.xml.ws.FaultAction;
 import javax.xml.ws.Holder;
+import java.util.concurrent.CompletionStage;
 
 @WebService(name = "MockService")
 public interface MockServiceJava {
 
-    public Promise<Bar> getBar(Foo foo);
+    CompletionStage<Bar> getBar(Foo foo);
 
-    public Promise<Integer> add(int a, int b);
+    CompletionStage<Integer> add(int a, int b);
 
-    public Promise<String> multiReturn(Holder<String> part, String toSplit, int index);
+    CompletionStage<String> multiReturn(Holder<String> part, String toSplit, int index);
 
-    public Promise<Void> noReturn(String nothing);
+    CompletionStage<Void> noReturn(String nothing);
 
     @Action(fault = {
             @FaultAction(className = SomeException.class)
     })
-    public Promise<String> declaredException();
+    CompletionStage<String> declaredException();
 
-    public Promise<String> runtimeException();
+    CompletionStage<String> runtimeException();
 }

--- a/client/src/test/scala/play/soap/PlayJaxWsClientProxySpec.scala
+++ b/client/src/test/scala/play/soap/PlayJaxWsClientProxySpec.scala
@@ -4,21 +4,21 @@
 package play.soap
 
 import java.net.ServerSocket
-import javax.xml.ws.{Holder, Endpoint}
+import java.util.concurrent.CompletionStage
+import javax.xml.ws.{Endpoint, Holder}
 
 import org.apache.cxf.jaxws.EndpointImpl
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
-import play.libs.F.Promise
 import play.soap.mockservice._
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-
 import org.apache.cxf.binding.soap.SoapFault
 
-class PlayJaxWsClientProxySpec extends Specification with NoTimeConversions {
+import scala.compat.java8.FutureConverters
+
+class PlayJaxWsClientProxySpec extends Specification {
 
   sequential
 
@@ -104,7 +104,7 @@ class PlayJaxWsClientProxySpec extends Specification with NoTimeConversions {
 
   def await[T](future: Future[T]): T = Await.result(future, 10.seconds)
 
-  def await[T](promise: Promise[T]): T = await(promise.wrapped())
+  def await[T](completionStage: CompletionStage[T]): T = await(FutureConverters.toScala(completionStage))
 
   def withScalaClient[T](block: MockServiceScala => T): T = withClient(block)
 

--- a/docs/Handlers.md
+++ b/docs/Handlers.md
@@ -126,6 +126,6 @@ You can see that the SOAP message is also being loaded so that it can be logged,
 
 To use the logging handler that we implemented, we can supply it to get method for our port from the service.  For example, to use it with the `HelloWorldService` that we saw earlier in the documentation, simply pass the list of handlers to the `helloWorld` method, like so:
 
-```java
+```scala
 val client: HelloWorld = helloWorldService.helloWorld(new LoggingHandler)
 ```

--- a/docs/SbtWsdl.md
+++ b/docs/SbtWsdl.md
@@ -26,7 +26,7 @@ The other is to place WSDLs in the `conf/wsdls` directory for a Play project, or
 
 ### Selecting the future API
 
-sbt WSDL can generate clients to either return `scala.concurrent.Future` for Scala projects, or `play.libs.F.Promise` for Java projects.  If your project is a Play project, the future API will automatically be selected based on whether you enabled the `PlayJava` or `PlayScala` plugin.  If it's an ordinary sbt project, it will default to `scala.concurrent.Future`.  This can be configured to use the Java promise using the `futureApi` setting:
+sbt WSDL can generate clients to either return `scala.concurrent.Future` for Scala projects, or `java.util.concurrent.CompletionStage` for Java projects.  If your project is a Play project, the future API will automatically be selected based on whether you enabled the `PlayJava` or `PlayScala` plugin.  If it's an ordinary sbt project, it will default to `scala.concurrent.Future`.  This can be configured to use the Java promise using the `futureApi` setting:
 
 ```scala
 WsdlKeys.futureApi := WsdlKeys.PlayJavaFutureApi

--- a/docs/SbtWsdl.md
+++ b/docs/SbtWsdl.md
@@ -5,7 +5,7 @@
 To install sbt WSDL into your Play project, add the following dependency to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % "1.0.0-M1")
+addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % "1.1.0")
 ```
 
 The plugin is automatically activated on install, and this will also cause the necessary Play SOAP client libraries to be added to your project.

--- a/docs/SbtWsdl.md
+++ b/docs/SbtWsdl.md
@@ -5,7 +5,7 @@
 To install sbt WSDL into your Play project, add the following dependency to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % "1.1.0")
 ```
 
 The plugin is automatically activated on install, and this will also cause the necessary Play SOAP client libraries to be added to your project.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -28,7 +28,7 @@ public class AuthenticationHandler implements SOAPHandler<SOAPMessageContext> {
             // Get headers, create if null
             Map<String, List<String>> headers = (Map) context.get(MessageContext.HTTP_REQUEST_HEADERS);
             if (headers == null) {
-                headers = new HashMap<String, List<String>>();
+                headers = new HashMap<>();
             }
 
             // Add authentication header

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Common {
-  val CxfVersion = "3.1.6"
+  val CxfVersion = "3.1.11"
   val PlayVersion = "2.5.14"
 
   val clientDeps = Seq(

--- a/sbt-plugin-testers/play-java-future/test/play/soap/sbtplugin/tester/HelloWorldTest.java
+++ b/sbt-plugin-testers/play-java-future/test/play/soap/sbtplugin/tester/HelloWorldTest.java
@@ -18,7 +18,9 @@ import org.junit.*;
 import play.soap.testservice.client.*;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
-import play.libs.F;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletionStage;
 
 import static org.junit.Assert.*;
 import static play.test.Helpers.*;
@@ -96,8 +98,12 @@ public class HelloWorldTest {
         });
     }
 
-    private static <T> T await(F.Promise<T> promise) {
-        return promise.get(10000); // 10 seconds
+    private static <T> T await(CompletionStage<T> promise) {
+        try {
+            return promise.toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     private static void withClient(Consumer<HelloWorld> block) {

--- a/sbt-plugin/src/main/scala/play/soap/sbtplugin/FutureGenerator.scala
+++ b/sbt-plugin/src/main/scala/play/soap/sbtplugin/FutureGenerator.scala
@@ -26,9 +26,9 @@ class FutureGenerator(futureApi: FutureApi) {
 
   /**
    * Generate the correct future type that holds the given Java type. E.g. for a Java type of
-   * "void" this could be "scala.concurrent.Future<scala.Unit>" or "play.libs.F.Promise<Void>".
+   * "void" this could be "scala.concurrent.Future<scala.Unit>" or "java.util.concurrent.CompletionStage<Void>".
    * For a Java type of "int" it could be "scala.concurrent.Future<java.lang.Integer>" or
-   * "play.libs.F.Promise<java.lang.Integer>"
+   * "java.util.concurrent.CompletionStage<java.lang.Integer>"
    *
    * @param javaType The Java type to wrap.
    */

--- a/sbt-plugin/src/main/scala/play/soap/sbtplugin/SbtWsdl.scala
+++ b/sbt-plugin/src/main/scala/play/soap/sbtplugin/SbtWsdl.scala
@@ -62,7 +62,7 @@ object Imports {
      * The Play Java Promise API
      */
     case object PlayJavaFutureApi extends FutureApi {
-      val fqn = "play.libs.F.Promise"
+      val fqn = "java.util.concurrent.CompletionStage"
       val voidType = "Void"
     }
 

--- a/sbt-plugin/src/main/scala/play/soap/sbtplugin/Version.scala
+++ b/sbt-plugin/src/main/scala/play/soap/sbtplugin/Version.scala
@@ -25,7 +25,7 @@ object Version {
   /**
    * The version of the sbt plugin
    */
-  lazy val pluginVersion = versionProps.getProperty("play-soap-sbt.version")
+  lazy val pluginVersion = versionProps.getProperty("sbt-play-soap.version")
 
   /**
    * The name of the plugin

--- a/sbt-plugin/src/sbt-test/play-soap/incremental-compilation/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/incremental-compilation/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) 2015-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) 2015-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) 2015-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/tests/play/soap/sbtplugin/tester/HelloWorldTest.java
+++ b/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/tests/play/soap/sbtplugin/tester/HelloWorldTest.java
@@ -18,7 +18,9 @@ import org.junit.*;
 import play.soap.testservice.client.*;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
-import play.libs.F;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletionStage;
 
 import static org.junit.Assert.*;
 import static play.test.Helpers.*;
@@ -59,7 +61,7 @@ public class HelloWorldTest {
             } catch (Exception ex) {
                 assertEquals(
                     "play.soap.testservice.client.HelloException_Exception: Hello world",
-                    ex.getMessage()
+                    ex.getCause().getMessage()
                 );
             }
         });
@@ -99,8 +101,12 @@ public class HelloWorldTest {
         });
     }
 
-    private static <T> T await(F.Promise<T> promise) {
-        return promise.get(10000); // 10 seconds
+    private static <T> T await(CompletionStage<T> promise) {
+        try {
+            return promise.toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     private static void withClient(Consumer<HelloWorld> block) {

--- a/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/tests/play/soap/sbtplugin/tester/PrimitivesTest.java
+++ b/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/tests/play/soap/sbtplugin/tester/PrimitivesTest.java
@@ -18,7 +18,9 @@ import org.junit.*;
 import play.soap.testservice.client.*;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
-import play.libs.F;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletionStage;
 
 import static org.junit.Assert.*;
 import static play.test.Helpers.*;
@@ -116,8 +118,13 @@ public class PrimitivesTest {
             assertEquals(Arrays.asList((short) 1, (short) 1, (short) 1), await(client.shortSequence(Arrays.asList((short) 1, (short) 1))))
         );
     }
-    private static <T> T await(F.Promise<T> promise) {
-        return promise.get(10000); // 10 seconds
+
+    private static <T> T await(CompletionStage<T> promise) {
+        try {
+            return promise.toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     private static void withClient(Consumer<Primitives> block) {

--- a/sbt-plugin/src/sbt-test/play-soap/simple-client-scala-future/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/simple-client-scala-future/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) 2015-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "play-soap-sbt" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))

--- a/scripts/generate-primitives.py
+++ b/scripts/generate-primitives.py
@@ -308,7 +308,8 @@ import org.junit.*;
 import play.soap.testservice.client.*;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
-import play.libs.F;
+
+import java.util.concurrent.CompletionStage;
 
 import static org.junit.Assert.*;
 import static play.test.Helpers.*;
@@ -337,8 +338,12 @@ public class PrimitivesTest {
     }}""")
 
   gen(f, """
-    private static <T> T await(F.Promise<T> promise) {
-        return promise.get(10000); // 10 seconds
+    private static <T> T await(CompletionStage<T> promise) {
+        try {
+            return promise.toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     private static void withClient(Consumer<Primitives> block) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.4-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
1. Update CXF to newer version
2. Remove deprecated `F.Promise` usage
3. Rename plugin artifact to be consistent with other plugins officially supported.