### PR TITLE
Fix #48, Repeatable annotation type

### DIFF
--- a/client/src/main/scala/play/soap/PlayJaxWsServiceFactoryBean.scala
+++ b/client/src/main/scala/play/soap/PlayJaxWsServiceFactoryBean.scala
@@ -4,28 +4,12 @@
 package play.soap
 
 import java.lang.reflect.Method
-import javax.xml.ws.FaultAction
-import javax.xml.ws.Action
 
 import org.apache.cxf.jaxws.support.JaxWsImplementorInfo
 import org.apache.cxf.jaxws.support.JaxWsServiceFactoryBean
 import org.apache.cxf.service.model.OperationInfo
-import org.apache.cxf.service.model.InterfaceInfo
 
 private[soap] class PlayJaxWsServiceFactoryBean extends JaxWsServiceFactoryBean {
-
-  /**
-   * Since we're returning futures, we don't set a throws clause, because the method doesn't throw anything,
-   * it redeems its returned future with a failure.  This means though that the automatic binding doesn't detect the
-   * faults.  So, instead, we add them as explicit action faults, and bind them here.
-   */
-  override def initializeFaults(service: InterfaceInfo, op: OperationInfo, method: Method) = {
-    // Ignore the declared faults
-    val faults = Option(method.getAnnotation(classOf[Action])).fold(Array.empty[FaultAction])(_.fault())
-    faults.foreach { fault =>
-      addFault(service, op, fault.className())
-    }
-  }
 
   /**
    * Massive hack here.

--- a/client/src/test/java/play/soap/mockservice/MockServiceJava.java
+++ b/client/src/test/java/play/soap/mockservice/MockServiceJava.java
@@ -3,11 +3,11 @@
  */
 package play.soap.mockservice;
 
+import java.util.concurrent.CompletionStage;
 import javax.jws.WebService;
 import javax.xml.ws.Action;
 import javax.xml.ws.FaultAction;
 import javax.xml.ws.Holder;
-import java.util.concurrent.CompletionStage;
 
 @WebService(name = "MockService")
 public interface MockServiceJava {
@@ -21,7 +21,7 @@ public interface MockServiceJava {
   CompletionStage<Void> noReturn(String nothing);
 
   @Action(fault = {@FaultAction(className = SomeException.class)})
-  CompletionStage<String> declaredException();
+  CompletionStage<String> declaredException() throws SomeException;
 
   CompletionStage<String> runtimeException();
 }

--- a/client/src/test/java/play/soap/mockservice/MockServiceScala.java
+++ b/client/src/test/java/play/soap/mockservice/MockServiceScala.java
@@ -23,7 +23,7 @@ public interface MockServiceScala {
   public Future<Unit> noReturn(String nothing);
 
   @Action(fault = {@FaultAction(className = SomeException.class)})
-  public Future<String> declaredException();
+  public Future<String> declaredException() throws SomeException;
 
   public Future<String> runtimeException();
 }

--- a/sbt-plugin/src/main/resources/play/soap/sbtplugin/sei.vm
+++ b/sbt-plugin/src/main/resources/play/soap/sbtplugin/sei.vm
@@ -37,8 +37,6 @@ import javax.annotation.Generated;
 #foreach ($import in $intf.Imports)
 import ${import};
 #end
-import javax.xml.ws.Action;
-import javax.xml.ws.FaultAction;
 
 /**
 #if ($intf.classJavaDoc != "")
@@ -66,13 +64,6 @@ public interface $intf.Name {
     #end
     #foreach ($annotation in $method.Annotations)
         $annotation
-    #end
-    #if($method.Exceptions.size() > 0)
-        @Action(fault = {
-          #foreach($exception in $method.Exceptions)
-            @FaultAction(className = ${exception.ClassName}.class)#if($method.Exceptions.size() != $foreach.count),#end
-          #end
-        })
     #end
     #if ($markGenerated == "true")
     @Generated(value = "$generatorclass", date = "$currentdate")


### PR DESCRIPTION
Fixes: #48 
Removed additional Action-annotation that was created specifically for exceptions, since this is invalid and won't compile. Also the exceptions are part of the original Action-annotation, so nothing is lost.