### PR TITLE
Change groupId of plugin to com.typesafe.play

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,6 @@ lazy val plugin = project
   .enablePlugins(SbtPlugin)
   .settings(
     name         := "sbt-play-soap",
-    organization := "com.typesafe.sbt",
     description  := "play-soap sbt plugin",
     Dependencies.plugin,
     crossScalaVersions := Seq(scala212),

--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,8 @@ lazy val plugin = project
   .in(file("sbt-plugin"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name         := "sbt-play-soap",
-    description  := "play-soap sbt plugin",
+    name        := "sbt-play-soap",
+    description := "play-soap sbt plugin",
     Dependencies.plugin,
     crossScalaVersions := Seq(scala212),
     addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Versions.Play),

--- a/sbt-plugin/src/sbt-test/play-soap/incremental-compilation/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/incremental-compilation/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/simple-client-play-java-future/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/play-soap/simple-client-scala-future/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/play-soap/simple-client-scala-future/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
  * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))


### PR DESCRIPTION
We don't have access to `com.typesafe.sbt` (anymore). We had the same problem in twirl, where we also moved to `com.typesafe.play` for its sbt plugin. So we will do the same here.
(By removing the setting, the fallback to https://github.com/playframework/play-soap/blob/a1ba7eedd6f6f40ec3ff529085ca9b1b8903b5b2/project/Common.scala#L21 will kick in).