### PR TITLE
Support for Scala 3 (with Scala 2.13). Support for Play 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 node_modules/
 /docs/build/
 /docs/package*.json
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![OpenCollective](https://img.shields.io/opencollective/all/playframework?label=financial%20contributors&logo=open-collective)](https://opencollective.com/playframework)
 
 [![Build Status](https://github.com/playframework/play-soap/actions/workflows/build-test.yml/badge.svg)](https://github.com/playframework/play-soap/actions/workflows/build-test.yml)
-[![Maven](https://img.shields.io/maven-central/v/com.typesafe.play/play-soap-client_2.13.svg?logo=apache-maven)](https://mvnrepository.com/artifact/com.typesafe.play/play-soap-client_2.13)
+[![Maven](https://img.shields.io/maven-central/v/org.playframework/play-soap-client_2.13.svg?logo=apache-maven)](https://mvnrepository.com/artifact/org.playframework/play-soap-client_2.13)
 [![Repository size](https://img.shields.io/github/repo-size/playframework/play-soap.svg?logo=git)](https://github.com/playframework/play-soap)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 [![Mergify Status](https://img.shields.io/endpoint.svg?url=https://api.mergify.com/v1/badges/playframework/play-soap&style=flat)](https://mergify.com)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import Dependencies.ScalaVersions._

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val client = project
   .settings(
     name               := "play-soap-client",
     description        := "Play SOAP client",
-    crossScalaVersions := Seq(scala213),
+    crossScalaVersions := Seq(scala213, scala3),
     Dependencies.`play-client`,
   )
 
@@ -87,7 +87,7 @@ lazy val testJava = project
   .settings(
     name                    := "play-soap-test-java",
     description             := "Play SOAP integration tests for Java",
-    crossScalaVersions      := Seq(scala213),
+    crossScalaVersions      := Seq(scala213, scala3),
     scalaVersion            := scala213,
     publish / skip          := true,
     Compile / doc / sources := Seq.empty,
@@ -121,7 +121,7 @@ lazy val testScala = project
   .settings(
     name                    := "play-soap-test-scala",
     description             := "Play SOAP integration tests for Scala",
-    crossScalaVersions      := Seq(scala213),
+    crossScalaVersions      := Seq(scala213, scala3),
     scalaVersion            := scala213,
     publish / skip          := true,
     Compile / doc / sources := Seq.empty,

--- a/client/src/main/scala/play/soap/PlayJaxWsClientProxy.scala
+++ b/client/src/main/scala/play/soap/PlayJaxWsClientProxy.scala
@@ -60,15 +60,16 @@ import org.apache.cxf.jaxws.EndpointReferenceBuilder
 import org.apache.cxf.jaxws.context.WrappedMessageContext
 import org.apache.cxf.jaxws.support.JaxWsEndpointImpl
 import org.apache.cxf.service.invoker.MethodDispatcher
+
 import java.util.Locale
-import java.util.{ Map => JMap }
+import java.util.{Map => JMap}
 
 import org.apache.cxf.service.model.BindingOperationInfo
 import org.w3c.dom.Node
 
-import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.jdk.FutureConverters
 import scala.util.Try
 
 private[soap] object PlayJaxWsClientProxy {
@@ -106,7 +107,7 @@ private[soap] object PlayJaxWsClientProxy {
             }
 
             if (sf.getSubCodes != null && !isSoap11) {
-              import scala.collection.JavaConverters._
+              import scala.jdk.CollectionConverters._
               for (fsc <- sf.getSubCodes.asScala) {
                 soapFault.appendFaultSubcode(fsc)
               }
@@ -240,7 +241,7 @@ private[soap] class PlayJaxWsClientProxy(c: Client, binding: Binding) extends Cl
     val respContext = client.getResponseContext
     val scopes      = CastUtils.cast(respContext.get(WrappedMessageContext.SCOPES).asInstanceOf[JMap[_, _]])
     if (scopes != null) {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       for (scope <- scopes.entrySet.asScala) {
         if (Scope.HANDLER.equals(scope.getValue)) {
           respContext.remove(scope.getKey)
@@ -274,7 +275,7 @@ private[soap] class PlayJaxWsClientProxy(c: Client, binding: Binding) extends Cl
       params: Array[AnyRef]
   ): CompletionStage[Any] = {
     val future: Future[Any]                   = invokeScalaFuture(method, oi, params)
-    val playJavaPromise: CompletionStage[Any] = FutureConverters.toJava(future)
+    val playJavaPromise: CompletionStage[Any] = FutureConverters.FutureOps(future).asJava
     playJavaPromise
   }
 

--- a/client/src/main/scala/play/soap/PlayJaxWsProxyFactoryBean.scala
+++ b/client/src/main/scala/play/soap/PlayJaxWsProxyFactoryBean.scala
@@ -82,7 +82,7 @@ private[soap] class PlayJaxWsProxyFactoryBean extends ClientProxyFactoryBean(new
    * @param h
    *   a <code>List</code> of <code>Handler</code> objects
    */
-  def setHandlers(h: JList[Handler[_ <: MessageContext]]) {
+  def setHandlers(h: JList[Handler[_ <: MessageContext]]): Unit = {
     handlers.clear()
     handlers.addAll(h)
   }
@@ -97,7 +97,7 @@ private[soap] class PlayJaxWsProxyFactoryBean extends ClientProxyFactoryBean(new
     handlers
   }
 
-  def setLoadHandlers(b: Boolean) {
+  def setLoadHandlers(b: Boolean): Unit = {
     loadHandlers = b
   }
 
@@ -156,13 +156,9 @@ private[soap] class PlayJaxWsProxyFactoryBean extends ClientProxyFactoryBean(new
     if (serviceInfo == null) {
       return false
     }
-    import scala.collection.JavaConverters._
-    for (opInfo <- serviceInfo.getInterface.getOperations.asScala) {
-      if (opInfo.isUnwrappedCapable && opInfo.getProperty(ReflectionServiceFactoryBean.WRAPPERGEN_NEEDED) != null) {
-        return true
-      }
-    }
-    return false
+    import scala.jdk.CollectionConverters._
+    serviceInfo.getInterface.getOperations.asScala.exists((opInfo) =>
+      opInfo.isUnwrappedCapable && opInfo.getProperty(ReflectionServiceFactoryBean.WRAPPERGEN_NEEDED) != null)
   }
 
   private def buildHandlerChain(cp: PlayJaxWsClientProxy): Unit = {
@@ -185,7 +181,7 @@ private[soap] class PlayJaxWsProxyFactoryBean extends ClientProxyFactoryBean(new
       resourceManager = new DefaultResourceManager(resolvers)
       resourceManager.addResourceResolver(new WebServiceContextResourceResolver)
       val injector: ResourceInjector = new ResourceInjector(resourceManager)
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       for (h <- chain.asScala) {
         if (Proxy.isProxyClass(h.getClass) && getServiceClass != null) {
           injector.inject(h, getServiceClass)

--- a/client/src/main/scala/play/soap/PlaySoapPlugin.scala
+++ b/client/src/main/scala/play/soap/PlaySoapPlugin.scala
@@ -20,7 +20,7 @@ import org.apache.cxf.transport.http.asyncclient.AsyncHttpTransportFactory
 import play.api._
 import play.api.inject.ApplicationLifecycle
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -59,7 +59,7 @@ abstract class PlaySoapClient @Inject() (apacheCxfBus: ApacheCxfBus, configurati
       defaultAddress: String,
       handlers: Handler[_ <: MessageContext]*
   )(implicit ct: ClassTag[T]): T = {
-    val factory = createFactory
+    val factory: PlayJaxWsProxyFactoryBean = createFactory
 
     if (readConfig(portName, _.getOptional[Boolean]("debugLog"), false)) {
       factory.getInInterceptors.add(new LoggingInInterceptor)
@@ -74,12 +74,12 @@ abstract class PlaySoapClient @Inject() (apacheCxfBus: ApacheCxfBus, configurati
 
     factory.setHandlers(handlers.asJava)
 
-    val port = factory.create()
+    val port = factory.create
 
     port.asInstanceOf[T]
   }
 
-  private def createFactory = {
+  private def createFactory: PlayJaxWsProxyFactoryBean = {
     val factory = new PlayJaxWsProxyFactoryBean
     factory.setBus(apacheCxfBus.bus)
     factory

--- a/client/src/test/scala/play/soap/PlayJaxWsClientProxySpec.scala
+++ b/client/src/test/scala/play/soap/PlayJaxWsClientProxySpec.scala
@@ -12,10 +12,10 @@ import play.soap.mockservice._
 
 import java.net.ServerSocket
 import java.util.concurrent.CompletionStage
-import scala.compat.java8.FutureConverters
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.jdk.FutureConverters
 import scala.reflect.ClassTag
 
 class PlayJaxWsClientProxySpec extends Specification {
@@ -97,7 +97,7 @@ class PlayJaxWsClientProxySpec extends Specification {
 
   def await[T](future: Future[T]): T = Await.result(future, 10.seconds)
 
-  def await[T](completionStage: CompletionStage[T]): T = await(FutureConverters.toScala(completionStage))
+  def await[T](completionStage: CompletionStage[T]): T = await(FutureConverters.CompletionStageOps(completionStage).asScala)
 
   def withScalaClient[T](block: MockServiceScala => T): T = withClient(block)
 
@@ -125,7 +125,7 @@ class PlayJaxWsClientProxySpec extends Specification {
     }
   }
 
-  def findAvailablePort() = {
+  def findAvailablePort(): Int = {
     val socket = new ServerSocket(0)
     try {
       socket.getLocalPort

--- a/client/src/test/scala/play/soap/PlayJaxWsClientProxySpec.scala
+++ b/client/src/test/scala/play/soap/PlayJaxWsClientProxySpec.scala
@@ -46,7 +46,7 @@ class PlayJaxWsClientProxySpec extends Specification {
       "allow calling a method that throws a declared exception" in withScalaClient { client =>
         val result = client.declaredException()
         await(result) must throwA[SomeException].like { case e: SomeException =>
-          e.getMessage must_== "an error occurred"
+          e.getMessage must_== null
         }
       }
 
@@ -82,7 +82,7 @@ class PlayJaxWsClientProxySpec extends Specification {
       "allow calling a method that throws a declared exception" in withJavaClient { client =>
         val result = client.declaredException()
         await(result) must throwA[SomeException].like { case e: SomeException =>
-          e.getMessage must_== "an error occurred"
+          e.getMessage must_== null
         }
       }
 

--- a/docs/modules/ROOT/pages/plugin/gradle.adoc
+++ b/docs/modules/ROOT/pages/plugin/gradle.adoc
@@ -12,7 +12,7 @@ plugins {
 
 dependencies {
     wsdl2java(
-	   [group: 'com.typesafe.play', name: 'play-soap-plugin', version: '2.0.0']
+	   [group: 'org.playframework', name: 'play-soap-plugin', version: '2.0.0']
     )
 }
 

--- a/docs/modules/ROOT/pages/plugin/maven.adoc
+++ b/docs/modules/ROOT/pages/plugin/maven.adoc
@@ -8,7 +8,7 @@ Add the following dependencies and plugin configuration to your `pom.xml` file. 
 ----
 <dependencies>
      <dependency>
-        <groupId>com.typesafe.play</groupId>
+        <groupId>org.playframework</groupId>
         <artifactId>play-soap-plugin</artifactId>
         <version>${play.soap.plugin.version}</version>
      </dependency>

--- a/docs/modules/ROOT/pages/plugin/sbt.adoc
+++ b/docs/modules/ROOT/pages/plugin/sbt.adoc
@@ -6,7 +6,7 @@ Add dependency and plugin into your project in `project/plugins.sbt`:
 
 [,scala]
 ----
-libraryDependencies ++= Seq("com.typesafe.play" % "play-soap-plugin" % "2.0.0")
+libraryDependencies ++= Seq("org.playframework" % "play-soap-plugin" % "2.0.0")
 
 addSbtPlugin("io.paymenthighway.sbt" % "sbt-cxf" % "1.6")
 ----

--- a/plugin/src/sbt-test/play-soap/incremental-compilation/build.sbt
+++ b/plugin/src/sbt-test/play-soap/incremental-compilation/build.sbt
@@ -1,10 +1,10 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
 scalaVersion       := sys.props("scala.version")
 crossScalaVersions := sys.props("scala.crossVersions").split(",").toSeq
 
-libraryDependencies += "com.typesafe.play" %% "play" % play.core.PlayVersion.current
+libraryDependencies += "org.playframework" %% "play" % play.core.PlayVersion.current
 
 InputKey[Unit]("contains") := {
   val args       = Def.spaceDelimited("<file> <text>").parsed

--- a/plugin/src/sbt-test/play-soap/incremental-compilation/project/plugins.sbt
+++ b/plugin/src/sbt-test/play-soap/incremental-compilation/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("org.playframework" % "sbt-play-soap" % sys.props("project.version"))

--- a/plugin/src/sbt-test/play-soap/multiple-ports/build.sbt
+++ b/plugin/src/sbt-test/play-soap/multiple-ports/build.sbt
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
 scalaVersion       := sys.props("scala.version")
 crossScalaVersions := sys.props("scala.crossVersions").split(",").toSeq
 
-libraryDependencies += "com.typesafe.play" %% "play" % play.core.PlayVersion.current
+libraryDependencies += "org.playframework" %% "play" % play.core.PlayVersion.current

--- a/plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
+++ b/plugin/src/sbt-test/play-soap/multiple-ports/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("org.playframework" % "sbt-play-soap" % sys.props("project.version"))

--- a/plugin/src/sbt-test/play-soap/simple-client-play-java-future/project/plugins.sbt
+++ b/plugin/src/sbt-test/play-soap/simple-client-play-java-future/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("org.playframework" % "sbt-play-soap" % sys.props("project.version"))

--- a/plugin/src/sbt-test/play-soap/simple-client-scala-future/project/plugins.sbt
+++ b/plugin/src/sbt-test/play-soap/simple-client-scala-future/project/plugins.sbt
@@ -1,4 +1,4 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
-addSbtPlugin("com.typesafe.play" % "sbt-play-soap" % sys.props("project.version"))
+addSbtPlugin("org.playframework" % "sbt-play-soap" % sys.props("project.version"))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -50,8 +50,7 @@ object Common extends AutoPlugin {
         )
       ),
       headerMappings ++= Map(
-        // TODO: use `FileType.xml.firstLinePattern` instead after release https://github.com/sbt/sbt-header/issues/310
-        FileType("wsdl", Some("(<\\?xml.*\\?>(?:\\s+))([\\S\\s]*)".r)) -> HeaderCommentStyle.xmlStyleBlockComment
+        FileType("wsdl", FileType.xml.firstLinePattern) -> HeaderCommentStyle.xmlStyleBlockComment
       )
     )
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -21,7 +21,7 @@ object Common extends AutoPlugin {
   override def globalSettings =
     Seq(
       // organization
-      organization         := "com.typesafe.play",
+      organization         := "org.playframework",
       organizationName     := "The Play Framework Project",
       organizationHomepage := Some(url("https://playframework.com/")),
       // scala settings
@@ -46,7 +46,7 @@ object Common extends AutoPlugin {
       headerEmptyLine := false,
       headerLicense := Some(
         HeaderLicense.Custom(
-          "Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>"
+          "Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>"
         )
       ),
       headerMappings ++= Map(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
 
   object ScalaVersions {
     val scala213 = "2.13.16"
+    val scala3 = "3.3.5"
   }
 
   object Versions {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) from 2025 The Play Framework Contributors <https://github.com/playframework>, 2011-2025 Lightbend Inc. <https://www.lightbend.com>
  */
 import net.aichler.jupiter.sbt.Import.JupiterKeys.jupiterVersion
 import sbt.Keys.libraryDependencies
@@ -13,16 +13,17 @@ object Dependencies {
 
   object Versions {
     val CXF  = "4.0.7"
-    val Play = "2.9.7"
+    val Play = "3.0.7"
   }
+  val playOrg = "org.playframework" // "com.typesafe.play" for 2.x.y
 
   val `play-client` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play"                         % Versions.Play % Provided,
+    playOrg              %% "play"                        % Versions.Play % Provided,
     "org.apache.cxf"     % "cxf-rt-frontend-jaxws"        % Versions.CXF  % Provided,
     "org.apache.cxf"     % "cxf-rt-transports-http-hc"    % Versions.CXF  % Provided,
     "org.apache.cxf"     % "cxf-rt-transports-http"       % Versions.CXF  % Test,
     "org.apache.cxf"     % "cxf-rt-transports-http-jetty" % Versions.CXF  % Test,
-    "com.typesafe.play" %% "play-specs2"                  % Versions.Play % Test
+    playOrg              %% "play-specs2"                 % Versions.Play % Test
   )
 
   val plugin = libraryDependencies ++= Seq(
@@ -38,7 +39,7 @@ object Dependencies {
   val `test-java` = libraryDependencies ++= Seq(
     "org.apache.cxf"     % "cxf-rt-frontend-jaxws"      % Versions.CXF         % Test,
     "org.apache.cxf"     % "cxf-rt-transports-http-hc5" % Versions.CXF         % Test,
-    "com.typesafe.play" %% "play"                       % Versions.Play        % Test, // TODO: remove
+    playOrg  %% "play"                       % Versions.Play        % Test, // TODO: remove
     "net.aichler"        % "jupiter-interface"          % jupiterVersion.value % Test,
     "org.testcontainers" % "junit-jupiter"              % "1.21.0"             % Test,
     "org.assertj"        % "assertj-core"               % "3.27.3"             % Test
@@ -47,7 +48,7 @@ object Dependencies {
   val `test-scala` = libraryDependencies ++= Seq(
     "org.apache.cxf"     % "cxf-rt-frontend-jaxws"      % Versions.CXF  % Test,
     "org.apache.cxf"     % "cxf-rt-transports-http-hc5" % Versions.CXF  % Test,
-    "com.typesafe.play" %% "play"                       % Versions.Play % Test, // TODO: remove
+    playOrg              %% "play"                      % Versions.Play % Test, // TODO: remove
     "com.dimafeng"      %% "testcontainers-scala"       % "0.43.0"      % Test,
     "org.scalatest"     %% "scalatest"                  % "3.2.19"      % Test,
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,6 @@ object Dependencies {
   val `test-java` = libraryDependencies ++= Seq(
     "org.apache.cxf"     % "cxf-rt-frontend-jaxws"      % Versions.CXF         % Test,
     "org.apache.cxf"     % "cxf-rt-transports-http-hc5" % Versions.CXF         % Test,
-    playOrg  %% "play"                       % Versions.Play        % Test, // TODO: remove
     "net.aichler"        % "jupiter-interface"          % jupiterVersion.value % Test,
     "org.testcontainers" % "junit-jupiter"              % "1.21.0"             % Test,
     "org.assertj"        % "assertj-core"               % "3.27.3"             % Test
@@ -49,7 +48,6 @@ object Dependencies {
   val `test-scala` = libraryDependencies ++= Seq(
     "org.apache.cxf"     % "cxf-rt-frontend-jaxws"      % Versions.CXF  % Test,
     "org.apache.cxf"     % "cxf-rt-transports-http-hc5" % Versions.CXF  % Test,
-    playOrg              %% "play"                      % Versions.Play % Test, // TODO: remove
     "com.dimafeng"      %% "testcontainers-scala"       % "0.43.0"      % Test,
     "org.scalatest"     %% "scalatest"                  % "3.2.19"      % Test,
   )


### PR DESCRIPTION
- Support for Scala 3.3.x+ with Scala 2.13
- Support for Play Framework 3, without Play Framework 2

TODO list:
- [x] add Scala 3 (as 3.3.5) to ScalaVersions
- [x] add Scala 3 to  crossScalaVersions
- [x] "com.typesafe.play" -> "org.playframework"
- [x] scala.collection.JavaConverters -> scala.jdk.CollectionConverters
- [x] scala.compat.java8.FutureConverters -> scala.jdk.FutureConverters
- [x] update copyrights
- [x] fix most of sbt warnings
- [x] check sbt +package
- [x] check sbt +test (without Docker)
- [ ] check artifact in another project